### PR TITLE
fix(css): Make CI CSS global

### DIFF
--- a/config/preview-head.html
+++ b/config/preview-head.html
@@ -1,0 +1,9 @@
+<style>
+  .isCI > * {
+    max-height: 859px;
+  }
+
+  .isCI * {
+    color: transparent !important;
+  }
+</style>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picturebook",
-  "version": "1.0.29",
+  "version": "1.0.31",
   "description": "Opinionated Storybook Setup",
   "main": "index.js",
   "repository": "https://github.com/obartra/picturebook",

--- a/shared/ci.css
+++ b/shared/ci.css
@@ -1,7 +1,0 @@
-.isCI > * {
-  max-height: 859px;
-}
-
-.isCI * {
-  color: transparent !important;
-}

--- a/shared/withExtensions.js
+++ b/shared/withExtensions.js
@@ -1,16 +1,16 @@
 import * as React from 'react'
 import { WithNotes } from '@storybook/addon-notes'
-import style from './ci.css'
 
-export default function WithExtensions({ notes, className, ...props }) {
+export default function WithExtensions({ notes, className = '', ...props }) {
   const isCI = window.location.href.indexOf('isCI') !== -1
-  const classCI = isCI ? style.isCI : undefined
+  const classes = isCI ? ['isCI', className] : [className]
+  const classesStr = classes.join(' ')
 
   if (notes) {
     return (
       <div>
         <WithNotes notes={notes}>
-          <div {...props} className={classCI} />
+          <div {...props} className={classesStr} />
         </WithNotes>
       </div>
     )
@@ -18,7 +18,7 @@ export default function WithExtensions({ notes, className, ...props }) {
 
   return (
     <div>
-      <div {...props} className={classCI} />
+      <div {...props} className={classesStr} />
     </div>
   )
 }


### PR DESCRIPTION
PictureBook CSS required a specific css config, since it's only used in CI,
moving to `preview-head.html` as described here:

https://storybook.js.org/configurations/add-custom-head-tags/