### PR TITLE
feat(wrapStory): allow wrapping stories with additional wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Configure it creating `.picturebookrc` file on your root directory. The followin
 - **entryPoint**: The stories entry point (it should import `picturebook`)
 - **markdownFooter**: The markdown footer applied to all stories. The keyword `[[url]]` is translated to the specific story url if `storiesUrl` is specified.
 - **postcssConfig**: A path to a file exporting either a plain object that returns a postcss config. This is a convenience method in case you don't need to customize other webpack settings. If you want full control on how css is loaded, you can do so by modifying the `webpackConfig` parameter. It expects the same format than storybook (a function that will receive the default config as first parameter and the environment as the second one)
+- **wrapStory**: Path to an ES module that default exports a function that takes a story, and returns a wrapped version of that story. Useful for applying context providers that stories may depend on, or otherwise augmenting each story.
 
 ## ✏️ Usage
 

--- a/config/wrapStory.js
+++ b/config/wrapStory.js
@@ -1,1 +1,0 @@
-export default function(story) { return story }

--- a/config/wrapStory.js
+++ b/config/wrapStory.js
@@ -1,0 +1,1 @@
+export default function(story) { return story }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,12 @@ import { storiesOf } from '@storybook/react'
 import { withKnobs } from '@storybook/addon-knobs'
 import { storyFolders, WithExtensions } from './shared'
 
-const {default: wrapStory} = require(preval`module.exports=require('./params').wrapStory`)
+let wrapStory = require(preval`
+  const params = require('./params')
+  module.exports = params.wrapStory || 'lodash/identity'
+`)
+
+wrapStory = wrapStory.default || wrapStory
 
 function getDisplayName(WrappedComponent) {
   const defaultName = 'Component'

--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
+/* eslint-disable import/no-dynamic-require */
 import * as React from 'react'
 import { each } from 'lodash'
 import { storiesOf } from '@storybook/react'
 import { withKnobs } from '@storybook/addon-knobs'
 import { storyFolders, WithExtensions } from './shared'
+
+const {default: wrapStory} = require(preval`module.exports=require('./params').wrapStory`)
 
 function getDisplayName(WrappedComponent) {
   const defaultName = 'Component'
@@ -41,12 +44,16 @@ function configStories(storiesOfName, storiesModule) {
   }
 }
 
-function addStory({ story: WrappedComponent, notes, name }, component) {
-  component.add(name, () => (
-    <WithExtensions notes={notes}>
-      <WrappedComponent />
-    </WithExtensions>
-  ))
+function addStory({ story: Story, notes, name }, component) {
+  component.add(name, () => {
+    const wrappedComponent = (
+      <WithExtensions notes={notes}>
+        <Story />
+      </WithExtensions>
+    )
+
+    return wrapStory(wrappedComponent)
+  })
 }
 
 const components = {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picturebook",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "Opinionated Storybook Setup",
   "main": "index.js",
   "repository": "https://github.com/obartra/picturebook",

--- a/params.js
+++ b/params.js
@@ -15,7 +15,6 @@ const config = Object.assign({}, {
   entryPoint: join(picturebookPath, 'index.js'),
   image: {},
   markdownFooter: join(picturebookPath, 'shared/storyFolders/footer.md'),
-  wrapStory: join(picturebookPath, 'config/wrapStory'),
   picturebookPath,
   projectName: 'PictureBook',
   skip: [],

--- a/params.js
+++ b/params.js
@@ -10,6 +10,7 @@ const config = rc(name, {
   projectName: 'PictureBook',
   entryPoint: join(picturebookPath, 'index.js'),
   markdownFooter: join(picturebookPath, 'shared/storyFolders/footer.md'),
+  wrapStory: join(picturebookPath, 'config/wrapStory'),
   projectUrl: 'https://github.com/obartra/picturebook',
   picturebookPath,
   root,
@@ -148,6 +149,7 @@ const config = rc(name, {
   'picturebookPath',
   'postcssConfig',
   'storyPath',
+  'wrapStory',
   'webpackConfig',
 ].forEach(key => {
   if (key in config) {


### PR DESCRIPTION
Might be overkill to add the default wrapStory.js to config. The rationale was that we have a "default config" that mirrors the sort of setup we recommend for users to build.

Alternatively, we can do something different inside preval to conditionally return an identity function if the `wrapStory` option is not set. Although that might be annoying since we are doing additional parsing of the config value given to us by prepending the root directory to the path provided.