### PR TITLE
chore(deps): Remove react as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 🤖📗 PictureBook
 
-Automated React Storybook Setup
+Automated Storybook Setup
 
-Simplify React Storybook story creation and cross-browser image comparison testing
+Simplify Storybook story creation and cross-browser image comparison testing
 
 ## 💡 Rationale
 
@@ -26,6 +26,8 @@ This project aims to provide utility methods to simplify [Storybook](https://sto
 ```sh
 yarn add --dev picturebook @storybook/react nightwatch react
 ```
+
+React is used in the examples but you can also use any flavor of storybook you want.
 
 If you don't have Storybook set it up yet, follow [these instructions](https://storybook.js.org/basics/quick-start-guide/) first.
 
@@ -122,7 +124,7 @@ function loadStories({|
   storiesOf: any,
   storyFiles: $ReadOnlyArray<string>,
 |}): Array<StoryPaths & {|
-  main: () => React.Node,
+  main: () => any,
 |}>
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picturebook",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "description": "Opinionated Storybook Setup",
   "main": "dist/index.js",
   "browser": "dist/picturebook.web.js",
@@ -65,8 +65,6 @@
     "webpack-cli": "3.1.2"
   },
   "peerDependencies": {
-    "nightwatch": ">=0.9.x",
-    "react": ">= 15.x",
-    "react-dom": ">= 15.x"
+    "nightwatch": ">=0.9.x"
   }
 }

--- a/src/picturebook.types.js
+++ b/src/picturebook.types.js
@@ -1,6 +1,4 @@
 // @flow
-import * as React from 'react'
-
 export type StoryPaths = {|
   +name: string,
   +parents: $ReadOnlyArray<string>,
@@ -43,7 +41,7 @@ export type LoadStoryOptions = Options & {
 
 export type LoadedStory = {|
   ...$Exact<StoryPaths>,
-  +main: () => React.Node,
+  +main: () => any,
 |}
 
 export type ImgLog = {|


### PR DESCRIPTION
Remove React dependencies so that picturebook can work with any version of storybook.

It was already fairly independent, it comes at the expense of the return type of each story that it no longer needs to be a React.Node but that was already not enforced before (it's required with context).

Examples and tests still use `React` and `React-DOM` but these are dev dependencies.

Closes https://github.com/obartra/picturebook/issues/7