### PR TITLE
refactor(runTest): Allow user to add their own nightwatch bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picturebook",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "description": "Opinionated Storybook Setup",
   "main": "dist/index.js",
   "browser": "dist/picturebook.web.js",

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -75,6 +75,7 @@ function stopTunnel(exitCode: number): Promise<number> {
 
 function internalRunTests(
   configPath: string,
+  nightwatchBinaryPath: string,
   maxRetryAttempts: number
 ): Promise<number> {
   // run tests
@@ -85,7 +86,7 @@ function internalRunTests(
     params.push('--env', 'chrome')
   }
 
-  const nightwatch = spawn('./node_modules/.bin/nightwatch', params, {
+  const nightwatch = spawn(nightwatchBinaryPath, params, {
     stdio: 'pipe',
     env: process.env,
   })
@@ -147,6 +148,7 @@ function writeResults(
 }
 
 export default async function runTests({
+  nightwatchBinaryPath,
   configPath,
   storyRoot,
   overwrite,
@@ -155,6 +157,7 @@ export default async function runTests({
   outputPath,
   maxRetryAttempts = 0,
 }: {|
+  +nightwatchBinaryPath: string,
   +storyRoot: string,
   +files: Array<StoryPaths>,
   +overwrite: boolean,
@@ -171,7 +174,11 @@ export default async function runTests({
         await startTunnel(tunnel)
       }
 
-      exitCode = await internalRunTests(configPath, maxRetryAttempts)
+      exitCode = await internalRunTests(
+        configPath,
+        nightwatchBinaryPath,
+        maxRetryAttempts
+      )
     } while (shouldRetry)
 
     if (exitCode !== 0) {


### PR DESCRIPTION
Since nightwatch does not exist on picturebook's `./nightwatch/.bin/` anymore, users should add their own custom path to their nightwatch binary file.