### PR TITLE
refactor(runTest): Add retry callback to onClose of nightwatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picturebook",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "description": "Opinionated Storybook Setup",
   "main": "dist/index.js",
   "browser": "dist/picturebook.web.js",

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -28,10 +28,12 @@ function retry(resolve, reject, maxRetryAttempts) {
       shouldRetry = false
       reject(exitCode)
     } else {
-      console.log(
-        `Selenium server connection failed, attempting ${retryAttempts} of ${maxRetryAttempts} retries`
-      )
-      shouldRetry = true
+      shouldRetry = exitCode !== 0
+      if (shouldRetry) {
+        console.log(
+          `Selenium server connection failed, attempting ${retryAttempts} of ${maxRetryAttempts} retries`
+        )
+      }
       resolve(exitCode)
     }
   }
@@ -94,7 +96,7 @@ function internalRunTests(
 
   // terminate
   return new Promise((resolve, reject) => {
-    nightwatch.on('close', resolve)
+    nightwatch.on('close', retry(resolve, reject, maxRetryAttempts))
     nightwatch.on('error', retry(resolve, reject, maxRetryAttempts))
   })
 }


### PR DESCRIPTION
It appears that nightwatch doesn not trigger an `error`, but rather just an on `close`. To mitigate that problem, I've added the `retry()` callback to `nightwatch.on('close',...)