### PR TITLE
fix(path): Match path properly for special chars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picturebook",
-  "version": "2.0.0-beta.22",
+  "version": "2.0.0-beta.23",
   "description": "Opinionated Storybook Setup",
   "main": "dist/index.js",
   "browser": "dist/picturebook.web.js",

--- a/src/utils/folderStructure.js
+++ b/src/utils/folderStructure.js
@@ -15,8 +15,8 @@ function groupRelatedFiles(
     .reduce(removeFolderInPath, relativePath)
     .replace(/^(\.\/|\/)/, '')
 
-  // https://regex101.com/r/dqUZ6u/2
-  return (flattenedPath.match(/([^.]+)[a-z.0-9]+$/) || [])[1]
+  // https://regex101.com/r/dqUZ6u/3
+  return (flattenedPath.match(/([^.]+)[a-z0-9._-]+$/) || [])[1]
 }
 
 function deKebab(text) {


### PR DESCRIPTION
When you have a browser config name like `chrome-headless` or `chrome_headless`,
all hell breaks loose.

This change fixes that by updating the path regex to accept - and _ chars